### PR TITLE
Updated bundle param to be nullable

### DIFF
--- a/keyboardvisibility/src/main/java/com/viniciusmo/keyboardvisibility/WrapperActivityLifecycleCallback.kt
+++ b/keyboardvisibility/src/main/java/com/viniciusmo/keyboardvisibility/WrapperActivityLifecycleCallback.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 
 internal abstract class WrapperActivityLifecycleCallback internal constructor(private val currentActivity: Activity) : Application.ActivityLifecycleCallbacks {
 
-    override fun onActivityCreated(activity: Activity, bundle: Bundle) = Unit
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) = Unit
 
     override fun onActivityStarted(activity: Activity) = Unit
 


### PR DESCRIPTION
The docs specify that the `Bundle` param in the onActivityCreated function is nullable, so the override definition should match. Should fix #3